### PR TITLE
Add flatdict override

### DIFF
--- a/build-systems.toml
+++ b/build-systems.toml
@@ -32,6 +32,10 @@ flit-core = []
 flit-core = []
 flit-scm = []
 
+[flatdict]
+setuptools = []
+wheel = []
+
 [grpcio]
 setuptools = []
 


### PR DESCRIPTION
I haven't tested this in-situ in this repo, but I got this error:

```
flatdict> warning: Ignoring invalid `SSL_CERT_FILE`. File does not exist: /no-cert-file.crt.
flatdict> DEBUG Using request timeout of 30s
flatdict> Building wheel...
flatdict> DEBUG Proceeding without build isolation
flatdict> DEBUG Calling `setuptools.build_meta:__legacy__.build_wheel("/private/tmp/nix-build-flatdict-4.0.1.drv-0/flatdict-4.0.1/dist/", {}, None)`
flatdict> Traceback (most recent call last):
flatdict>   File "<string>", line 8, in <module>
flatdict> ModuleNotFoundError: No module named 'setuptools'
flatdict>   x Failed to build
flatdict>   | `/private/tmp/nix-build-flatdict-4.0.1.drv-0/flatdict-4.0.1`
flatdict>   |-> The build backend returned an error
flatdict>   `-> Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit
flatdict>       status: 1)
flatdict>       hint: This usually indicates a problem with the package or the build
flatdict>       environment.
```

Resolved with:

```nix
  pyprojectOverrides = final: prev: {
    flatdict = prev.flatdict.overrideAttrs (old: {
      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
        (final.resolveBuildSystem ({
          setuptools = [ ];
          wheel = [ ];
        }))
      ];
    });
  };
```

So I'm guessing this should fix it.